### PR TITLE
Remove dead mailing list link

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
 					</div><!-- /.col-sm-4 -->
 				</div><!-- .row -->
 				<div class="row">
-					<p><em>A game by <a href="http://www.steven.li/" target="_blank">Steven Li</a>. Based off the game <a href="https://boardgamegeek.com/boardgame/113289/snake-oil" target="_blank">Snake Oil</a>.</em><br><em>If you had fun, <a href="https://twitter.com/intent/tweet?text=www.steven.li%2Fsalesman" target="_blank">tweet about it</a> or <a href="http://eepurl.com/cxkP6j" target="_blank">sign up for emails</a>.</em></p>
+					<p><em>A game by <a href="http://www.steven.li/" target="_blank">Steven Li</a>. Based off the game <a href="https://boardgamegeek.com/boardgame/113289/snake-oil" target="_blank">Snake Oil</a>.</em></p>
 				</div><!-- .row -->
 			</div><!-- .main-game -->
 			<div class="overlay" id="overlay-submission">


### PR DESCRIPTION
Not sure why my Mailchimp account disappeared, but better to take down the links altogether.